### PR TITLE
Extend the rota to 9 months

### DIFF
--- a/lib/patterdale/out_of_hours/rotations.rb
+++ b/lib/patterdale/out_of_hours/rotations.rb
@@ -80,7 +80,7 @@ module Patterdale
       end
 
       def get_periods_for_schedule(schedule)
-        schedule.timeline(interval: 3, interval_unit: :months).select { |t| @ooh_rotation_ids.include?(t.id) }.map { |r| r.periods }.flatten
+        schedule.timeline(interval: 9, interval_unit: :months).select { |t| @ooh_rotation_ids.include?(t.id) }.map { |r| r.periods }.flatten
       end
 
       def find_user_for_date(periods, date)

--- a/lib/patterdale/support/rotations.rb
+++ b/lib/patterdale/support/rotations.rb
@@ -68,7 +68,7 @@ module Patterdale
       end
 
       def timelines
-        @timelines ||= schedule.timeline(interval: 3, interval_unit: :months)
+        @timelines ||= schedule.timeline(interval: 9, interval_unit: :months)
       end
 
       DisciplineSupportDay = Struct.new(:period, :timeline, keyword_init: true) {


### PR DESCRIPTION
The rota get set up to 9 months in advance. It would be good to have that available for people to see via ical or json