### PR TITLE
Swap Renovate config to use internal standard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["github>dxw/renovate-config:internal"]
 }


### PR DESCRIPTION
We have a new [standard config](https://github.com/dxw/renovate-config) we're trying out for Renovate, so all our internal repos behave the same way.

This also disables dependabot dependency updates, since Renovate handles them.