### PR TITLE
Remove use of uglifier in production environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "rails", "~> 7.0.6"
 gem "sass-rails", "~> 6.0"
 gem "turbolinks", "~> 5"
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]
-gem "uglifier", ">= 1.3.0"
 gem "redis-rails"
 gem "redis", "~> 4"
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,8 +24,6 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
   # Set a css_compressor so sassc-rails does not overwrite the compressor when running the tests
   config.assets.css_compressor = nil
 


### PR DESCRIPTION
Rails no longer does it this way.
https://www.mintbit.com/blog/rails-5-6-upgrade-es6-uglifier-bug